### PR TITLE
Fix link behaviour regarding tracked urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
       var trackOutbound = function(url) {
         ga('send', 'event', 'outbound', 'click', url, {
          'transport': 'beacon',
-         'hitCallback': function(){document.location = url;}
+         'hitCallback': function(){ window.open(url); }
         });
       }
     </script>

--- a/introduction/index.html
+++ b/introduction/index.html
@@ -355,7 +355,7 @@
       var trackOutbound = function(url) {
         ga('send', 'event', 'outbound', 'click', url, {
          'transport': 'beacon',
-         'hitCallback': function(){document.location = url;}
+         'hitCallback': function(){ window.open(url); }
         });
       }
     </script>

--- a/securing/index.html
+++ b/securing/index.html
@@ -897,7 +897,7 @@ public class ListController {
       var trackOutbound = function(url) {
         ga('send', 'event', 'outbound', 'click', url, {
          'transport': 'beacon',
-         'hitCallback': function(){document.location = url;}
+         'hitCallback': function(){ window.open(url); }
         });
       }
     </script>


### PR DESCRIPTION
trackOutbound function uses document.location to change the page location,
which breaks target="_blank" behaviour of opening links in tabs/windows.
Also breaks Ctrl+Click and Ctrl+Cmd+Click.

To me this is very annoying as it breaks a very basic browser function and is comparable to breaking the back button!