### PR TITLE
Fix incorrect filename

### DIFF
--- a/securing/part3.html
+++ b/securing/part3.html
@@ -127,7 +127,7 @@
 	<p>Once you have downloaded WebGoat, it can be started from the command line using the command:</p>
 
 <pre>
-java -jar webgoat-standalone-7.0.1-exec.jar -httpPort 8081</pre>
+java -jar webgoat-container-7.0.1-war-exec.jar -httpPort 8081</pre>
 
 	<p>This launches the WebGoat server on the port 8081. Once the server has been started, the application can be accessed at <code>http://localhost:8081/WebGoat</code>.</p> 
 


### PR DESCRIPTION
The filename is incorrect. If you download file from https://s3.amazonaws.com/webgoat-war/webgoat-container-7.0.1-war-exec.jar it should be "webgoat-container-7.0.1-war-exec.jar".

Incorrect command gives the following error:
```
java -jar webgoat-standalone-7.0.1-exec.jar -httpPort 8081
Error: Unable to access jarfile webgoat-standalone-7.0.1-exec.jar
```

I really trust very much that filename is correct, so took almost 1 hour for me to understand that error "Unable to access jarfile ..." due to this :smile:.