### PR TITLE
bowser.js is missing on some pages

### DIFF
--- a/advanced/index.html
+++ b/advanced/index.html
@@ -306,6 +306,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/advanced/part2.html
+++ b/advanced/part2.html
@@ -334,6 +334,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/advanced/part3.html
+++ b/advanced/part3.html
@@ -418,6 +418,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/advanced/part4.html
+++ b/advanced/part4.html
@@ -322,6 +322,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/advanced/part5.html
+++ b/advanced/part5.html
@@ -349,6 +349,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/index.html
+++ b/securing/index.html
@@ -952,6 +952,7 @@ public class ListController {
                                   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
                                   <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+                                  <script src="/assets/js/bowser/bowser.js"></script>
                                   <script src="/assets/js/csa.js"></script>
 
                                   <script>

--- a/securing/part2.html
+++ b/securing/part2.html
@@ -1108,6 +1108,7 @@ Content-Length: 10
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/part3.html
+++ b/securing/part3.html
@@ -463,6 +463,7 @@ Steps to reproduce:
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/part4.html
+++ b/securing/part4.html
@@ -648,6 +648,7 @@ qwertyuiop
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+		<script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/part4.html
+++ b/securing/part4.html
@@ -647,8 +647,8 @@ qwertyuiop
 
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
-		<script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
-		<script src="/assets/js/bowser/bowser.js"></script>
+    <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/part4.html
+++ b/securing/part4.html
@@ -647,7 +647,7 @@ qwertyuiop
 
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
-    <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+		<script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
 		<script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 

--- a/securing/part5.html
+++ b/securing/part5.html
@@ -456,6 +456,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>

--- a/securing/part6.html
+++ b/securing/part6.html
@@ -368,6 +368,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <script src="/assets/js/tmc-client-js/dist/tmc-client.min.js"></script>
+    <script src="/assets/js/bowser/bowser.js"></script>
     <script src="/assets/js/csa.js"></script>
 
     <script>


### PR DESCRIPTION
bowser.js is called on every page through csa.js, but is missing from HTML for all pages in /advanced & /securing
This adds them for those pages, so it doesn't throw an error anymore